### PR TITLE
Handle exception if pipe closed

### DIFF
--- a/lib/open4.rb
+++ b/lib/open4.rb
@@ -84,8 +84,12 @@ module Open4
         begin
           cmd.call(ps)
         rescue Exception => e
-          Marshal.dump(e, ps.last)
-          ps.last.flush
+          begin
+            Marshal.dump(e, ps.last)
+            ps.last.flush
+          rescue Errno::EPIPE
+            raise e
+          end
         ensure
           ps.last.close unless ps.last.closed?
         end

--- a/test/pfork4_test.rb
+++ b/test/pfork4_test.rb
@@ -145,6 +145,23 @@ class PFork4Test < TestCase
     assert_equal '', out_actual
     assert_equal '', err_actual
   end
+
+  def test_io_pipes_and_then_exception_without_block
+    via_msg = 'foo'
+    fun = lambda do
+      $stdout.write $stdin.read
+      raise MyError
+    end
+    out_actual, err_actual = nil, nil
+    cid, stdin, stdout, stderr = pfork4 fun
+    stdin.write via_msg
+    stdin.close
+    out_actual = stdout.read
+    err_actual = stderr.read
+    assert_equal via_msg, out_actual
+    assert_match "MyError", err_actual
+    assert_equal 1, wait_status(cid)
+  end
 end
 
 end


### PR DESCRIPTION
If pfork4 is called without a block and the code running in the fork
raises an exception, there is a good change that the read end of the IO
pipe for communicating exception information to the parent process will
already be closed.  In that case, raise an exception so that the parent
process can at least see it, if the parent is monitoring the child's
stderr.
